### PR TITLE
chore: Fix analyzer loopclosure warning

### DIFF
--- a/internal/rest/task_test.go
+++ b/internal/rest/task_test.go
@@ -71,6 +71,8 @@ func TestTasks_Delete(t *testing.T) {
 	//-
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -176,6 +178,8 @@ func TestTasks_Post(t *testing.T) {
 	//-
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -274,6 +278,8 @@ func TestTasks_Read(t *testing.T) {
 	//-
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -383,6 +389,8 @@ func TestTasks_Update(t *testing.T) {
 	//-
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Explanation:
https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/loopclosure

I while a go, while using a payment library called Recurly, I discovered a bug while using literal func inside of a loop. I created a go routine to fetch all the subscriptions and I got the same result in each iteration.